### PR TITLE
refactor: improve unsupported connector error

### DIFF
--- a/squad-server/factory.js
+++ b/squad-server/factory.js
@@ -152,7 +152,7 @@ export default class SquadServerFactory {
       return awn;
     }
 
-    throw new Error(`${type.connector} is an unsupported connector type.`);
+    throw new Error(`${type} is an unsupported connector type.`);
   }
 
   static parseConfig(configString) {


### PR DESCRIPTION
## Summary
- reference connector type directly in unsupported connector error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint squad-server/factory.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0ed234c6c832a8ea1d969b1f0d1b1