### PR TITLE
feat: secure config endpoint

### DIFF
--- a/squad-server/plugins/index.js
+++ b/squad-server/plugins/index.js
@@ -30,6 +30,7 @@ class Plugins {
           'base-plugin.js',
           'discord-base-message-updater.js',
           'discord-base-plugin.js',
+          'web-base-plugin.js',
           'readme.md'
         ].includes(dirent.name)
       )

--- a/squad-server/plugins/readme.md
+++ b/squad-server/plugins/readme.md
@@ -42,4 +42,9 @@ function aPluginToLogTeamkills(server){
 ```
 Various actions can be completed in a plugin. Most of these will involve outside system, e.g. Discord.js to run a Discord bot, so they are not documented here. However, you may run RCON commands using `server.rcon.execute("Command");`.
 
-If you're struggling to create a plugin, the existing [`plugins`](https://github.com/Team-Silver-Sphere/SquadJS/tree/master/squad-server/plugins) are a good place to go for examples or feel free to ask for help in the Squad RCON Discord. 
+If you're struggling to create a plugin, the existing [`plugins`](https://github.com/Team-Silver-Sphere/SquadJS/tree/master/squad-server/plugins) are a good place to go for examples or feel free to ask for help in the Squad RCON Discord.
+
+## Web Plugin Authentication
+The `WebBasePlugin` provides a lightweight HTTP server and protects `/config` routes with a simple token based middleware.
+
+Configure the `authToken` option for your plugin and supply the token in the `Authorization` header, as a `token` query parameter or via a cookie named using the `authCookieName` option.

--- a/squad-server/plugins/web-base-plugin.js
+++ b/squad-server/plugins/web-base-plugin.js
@@ -1,0 +1,111 @@
+import { createServer } from 'http';
+import BasePlugin from './base-plugin.js';
+
+/**
+ * Base class for plugins exposing a HTTP interface. It provides
+ * an authentication middleware that verifies a shared secret
+ * before any request to the `/config` endpoint is handled.
+ */
+export default class WebBasePlugin extends BasePlugin {
+  static get description() {
+    return (
+      'The <code>WebBasePlugin</code> provides a minimal HTTP server for plugins that need to expose a web interface. ' +
+      'Requests to <code>/config</code> are protected by a token or session cookie to prevent unauthorised access.'
+    );
+  }
+
+  static get defaultEnabled() {
+    return false;
+  }
+
+  static get optionsSpecification() {
+    return {
+      webPort: {
+        required: true,
+        description: 'Port for the internal HTTP server.',
+        default: 3001,
+        example: '3001'
+      },
+      authToken: {
+        required: true,
+        description:
+          'Shared secret used to authorise /config requests. The token may be supplied via the Authorization header, a `token` query parameter or a cookie.',
+        default: '',
+        example: 'ChangeMe'
+      },
+      authCookieName: {
+        required: false,
+        description: 'Cookie name checked for the auth token.',
+        default: 'session',
+        example: 'session'
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+    this.httpServer = createServer(this._handleRequest.bind(this));
+  }
+
+  async mount() {
+    this.httpServer.listen(this.options.webPort);
+  }
+
+  async unmount() {
+    this.httpServer.close();
+  }
+
+  /**
+   * Simple authentication middleware for /config requests.
+   * Returns true when the request is authorised.
+   */
+  _authenticate(req) {
+    const token = this.options.authToken;
+    if (!token) return true;
+
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (url.searchParams.get('token') === token) return true;
+
+    const header = req.headers.authorization || req.headers['x-auth-token'];
+    if (header) {
+      const parts = header.split(' ');
+      if (parts[parts.length - 1] === token) return true;
+    }
+
+    if (req.headers.cookie) {
+      const cookies = Object.fromEntries(
+        req.headers.cookie.split(';').map((c) => c.trim().split('='))
+      );
+      if (cookies[this.options.authCookieName] === token) return true;
+    }
+
+    return false;
+  }
+
+  _handleRequest(req, res) {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (url.pathname.startsWith('/config')) {
+      if (!this._authenticate(req)) {
+        res.writeHead(401);
+        res.end('Unauthorized');
+        return;
+      }
+      this.onConfigRequest(req, res, url);
+      return;
+    }
+
+    this.routeRequest(req, res, url);
+  }
+
+  // Methods intended to be overridden by subclasses
+  onConfigRequest(req, res) {
+    res.writeHead(404);
+    res.end();
+  }
+
+  routeRequest(req, res) {
+    res.writeHead(404);
+    res.end();
+  }
+}


### PR DESCRIPTION
## Summary
- add WebBasePlugin with token or cookie protection for /config
- document web plugin authentication options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0ed234744832a9829731c5efdbc6e