### PR TITLE
Add capped message buffer to web base plugin

### DIFF
--- a/squad-server/plugins/index.js
+++ b/squad-server/plugins/index.js
@@ -28,6 +28,7 @@ class Plugins {
         [
           'index.js',
           'base-plugin.js',
+          'web-base-plugin.js',
           'discord-base-message-updater.js',
           'discord-base-plugin.js',
           'readme.md'

--- a/squad-server/plugins/web-base-plugin.js
+++ b/squad-server/plugins/web-base-plugin.js
@@ -1,0 +1,35 @@
+import BasePlugin from './base-plugin.js';
+
+const DEFAULT_MAX_MESSAGES = 100;
+
+export default class WebBasePlugin extends BasePlugin {
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+
+    // maximum number of messages to retain in memory
+    this.maxMessages = options?.maxMessages || DEFAULT_MAX_MESSAGES;
+    this.messages = [];
+  }
+
+  /**
+   * Add a message to the internal buffer.
+   * Only the last `maxMessages` messages are kept in memory.
+   * When the buffer exceeds the cap, the oldest message is discarded.
+   *
+   * @param {*} message - message payload to store
+   */
+  addMessage(message) {
+    if (this.messages.length >= this.maxMessages) {
+      this.messages.shift();
+    }
+    this.messages.push(message);
+  }
+
+  /**
+   * Return a copy of the buffered messages
+   * @returns {Array} array containing buffered messages
+   */
+  getMessages() {
+    return [...this.messages];
+  }
+}


### PR DESCRIPTION
## Summary
- add WebBasePlugin with a capped message buffer that keeps the last 100 entries
- exclude WebBasePlugin from plugin loader list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0ed201d04832ab97cb5e3607fc2d0