### PR TITLE
feat: add web admin broadcast plugin

### DIFF
--- a/squad-server/plugins/index.js
+++ b/squad-server/plugins/index.js
@@ -30,6 +30,7 @@ class Plugins {
           'base-plugin.js',
           'discord-base-message-updater.js',
           'discord-base-plugin.js',
+          'web-base-plugin.js',
           'readme.md'
         ].includes(dirent.name)
       )

--- a/squad-server/plugins/web-admin-broadcast.js
+++ b/squad-server/plugins/web-admin-broadcast.js
@@ -1,9 +1,9 @@
-import DiscordBasePlugin from './discord-base-plugin.js';
+import WebBasePlugin from './web-base-plugin.js';
 
-export default class DiscordAdminBroadcast extends DiscordBasePlugin {
+export default class WebAdminBroadcast extends WebBasePlugin {
   static get description() {
     return (
-      'The <code>DiscordAdminBroadcast</code> plugin will send a copy of admin broadcasts made in game to a Discord ' +
+      'The <code>WebAdminBroadcast</code> plugin will send a copy of admin broadcasts made in game to a Web ' +
       'channel.'
     );
   }
@@ -14,7 +14,7 @@ export default class DiscordAdminBroadcast extends DiscordBasePlugin {
 
   static get optionsSpecification() {
     return {
-      ...DiscordBasePlugin.optionsSpecification,
+      ...WebBasePlugin.optionsSpecification,
       channelID: {
         required: true,
         description: 'The ID of the channel to log admin broadcasts to.',
@@ -44,7 +44,7 @@ export default class DiscordAdminBroadcast extends DiscordBasePlugin {
   }
 
   async onAdminBroadcast(info) {
-    await this.sendDiscordMessage({
+    await this.sendWebMessage({
       embed: {
         title: 'Admin Broadcast',
         color: this.options.color,

--- a/squad-server/plugins/web-base-plugin.js
+++ b/squad-server/plugins/web-base-plugin.js
@@ -1,0 +1,18 @@
+import BasePlugin from './base-plugin.js';
+
+import { COPYRIGHT_MESSAGE } from '../utils/constants.js';
+
+export default class WebBasePlugin extends BasePlugin {
+  static get optionsSpecification() {
+    return {};
+  }
+
+  async prepareToMount() {}
+
+  async sendWebMessage(message) {
+    if (typeof message === 'object' && 'embed' in message) {
+      message.embed.footer = message.embed.footer || { text: COPYRIGHT_MESSAGE };
+    }
+    this.server.emit('WEB_MESSAGE', message);
+  }
+}


### PR DESCRIPTION
## Summary
- add WebBasePlugin for browser messaging
- replace Discord admin broadcast plugin with Web variant

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0e98b555c832a9fcb3a474a0929b6