### PR TITLE
Add port option and unmount for WebBasePlugin

### DIFF
--- a/squad-server/plugins/index.js
+++ b/squad-server/plugins/index.js
@@ -30,6 +30,7 @@ class Plugins {
           'base-plugin.js',
           'discord-base-message-updater.js',
           'discord-base-plugin.js',
+          'web-base-plugin.js',
           'readme.md'
         ].includes(dirent.name)
       )

--- a/squad-server/plugins/web-base-plugin.js
+++ b/squad-server/plugins/web-base-plugin.js
@@ -1,0 +1,30 @@
+import { createServer } from 'http';
+
+import BasePlugin from './base-plugin.js';
+
+export default class WebBasePlugin extends BasePlugin {
+  static get optionsSpecification() {
+    return {
+      port: {
+        required: false,
+        description: 'Port to bind the web server to.',
+        default: 3000,
+        example: '3000'
+      }
+    };
+  }
+
+  constructor(server, options, connectors) {
+    super(server, options, connectors);
+
+    this.server = createServer();
+  }
+
+  async mount() {
+    this.server.listen(this.options.port);
+  }
+
+  async unmount() {
+    this.server.close();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce WebBasePlugin with configurable HTTP port and server lifecycle management
- prevent plugin loader from treating `web-base-plugin.js` as a plugin

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0e989efb0832a8d250af21e9ac6b3